### PR TITLE
Fixed fatal error while trying to switch page

### DIFF
--- a/src/interactions/buttons/inventoryChangePage.ts
+++ b/src/interactions/buttons/inventoryChangePage.ts
@@ -54,9 +54,8 @@ const event: BotEvent = {
 
         // If there are no items, send an error message
         if (items.length === 0) {
-            await interaction.reply({
-                embeds: [noItems(guild.lang)],
-                ephemeral: true,
+            await interaction.editReply({
+                embeds: [noItems(guild.lang)]
             });
             return;
         }

--- a/src/interactions/buttons/shopChangePage.ts
+++ b/src/interactions/buttons/shopChangePage.ts
@@ -39,9 +39,8 @@ const event: BotEvent = {
 
     // If there are no items, send an error message
     if (items.length === 0) {
-      await interaction.reply({
+      await interaction.editReply({
         embeds: [noItems(guild.lang)],
-        ephemeral: true,
       });
       return;
     }


### PR DESCRIPTION
Fixed an issue that caused a fatal error while trying to switch a page ( .reply was sometimes used, despite the fact that the reply was defered)